### PR TITLE
Remove assumption that uuids are somehow sortable

### DIFF
--- a/uuidcreatedtime/query.go
+++ b/uuidcreatedtime/query.go
@@ -44,7 +44,7 @@ func encodeCursor(t time.Time, uuid string) string {
 }
 
 func FetchPayment(ctx context.Context, db *sql.DB, params FetchParam) (res []pagination.Payment, nextCursor string, err error) {
-	queryBuilder := sq.Select("id", "amount", "name", "created_time").From("payment_with_uuid").PlaceholderFormat(sq.Dollar).OrderBy("created_time DESC, id DESC")
+	queryBuilder := sq.Select("id", "amount", "name", "created_time").From("payment_with_uuid").PlaceholderFormat(sq.Dollar).OrderBy("created_time DESC")
 
 	if params.Limit > 0 {
 		queryBuilder = queryBuilder.Limit(params.Limit)
@@ -59,7 +59,7 @@ func FetchPayment(ctx context.Context, db *sql.DB, params FetchParam) (res []pag
 		queryBuilder = queryBuilder.Where(sq.LtOrEq{
 			"created_time": createdCursor,
 		})
-		queryBuilder = queryBuilder.Where(sq.Lt{
+		queryBuilder = queryBuilder.Where(sq.NotEq{
 			"id": paymentID,
 		})
 	}


### PR DESCRIPTION
uuid's do not necessarily have to be ordered.
We want to avoid returning twice the same record, which we can achieve with a Not Equal test.
We can then remove the sort by id.

This also handles the case where two records have the same creation date, since we are including the date but excluding the id.